### PR TITLE
Fix broken label links on /issues page

### DIFF
--- a/template/js/index.js
+++ b/template/js/index.js
@@ -119,7 +119,7 @@ require('nighthawk')({
         <main>
           ${res.locals.issues.map(([tag, issues]) => html`
             <section>
-							<h1><a href="${config.baseUrl}/issues/${tag.name}">${tag.name}</a></h1>
+              <h1><a href="${config.baseUrl}/issues/${tag.name}">${tag.name}</a></h1>
 
               <div class="issues-list">
                 <ul>

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -119,7 +119,7 @@ require('nighthawk')({
         <main>
           ${res.locals.issues.map(([tag, issues]) => html`
             <section>
-              <h1><a href="${config.baseUrl}issues/${tag.name}">${tag.name}</a></h1>
+							<h1><a href="${config.baseUrl}/issues/${tag.name}">${tag.name}</a></h1>
 
               <div class="issues-list">
                 <ul>


### PR DESCRIPTION
Noticed that the h1's on the /issues page had broken links. Was missing a forward slash after `baseUrl`

Visit the [issues page](https://expressjs.github.io/statusboard/issues) and click "Top  Priority" and you're brought to https://expressjs.github.io/statusboardissues/top%20priority instead of https://expressjs.github.io/statusboard/issues/top%20priority