### PR TITLE
Don't assume the default branch is "master"

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -23,7 +23,7 @@ module.exports.Project = class Project {
     this.repo = repo
     this.repoOwner = repoOwner
     this.repoName = repoName
-    this.repoBranch = proj.repoBranch || 'master'
+    this.repoBranch = proj.repoBranch || 'HEAD'
     this.repoDirectory = proj.repoDirectory || '/'
     this.packageName = null
   }


### PR DESCRIPTION
For instance, https://github.com/nodejs/package-maintenance 's default branch is now main and "master" will return 404. Use `HEAD` as a default branch name so that we can get the latest stuff regardless of the branch name.