### PR TITLE
ci: use node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ permissions:
   pages: write
   id-token: write
 
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -29,7 +28,7 @@ jobs:
       uses: actions/configure-pages@v5
     - uses: actions/setup-node@v4
       with:
-        node-version: 12
+        node-version: 20
     - uses: actions/cache@v4
       id: cache
       with:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
I had forgotten to update the Node.js version in the workflow, that's why the build of the statusboard was failing. Now it uses version 20 and works correctly.