### PR TITLE
replace libnpm

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,5 +1,5 @@
 'use strict'
-const libnpm = require('libnpm')
+const pacote = require('pacote')
 
 const Packument = module.exports.Packument =
 class Packument {
@@ -12,7 +12,7 @@ class Packument {
 }
 
 module.exports.getPackument = async function getNpmPackument (packageName) {
-  const resp = await libnpm.packument(packageName)
+  const resp = await pacote.packument(packageName)
   return new Packument(resp)
 }
 
@@ -30,6 +30,6 @@ class Manifest {
   }
 }
 module.exports.getManifest = async function getNpmManifest (packageName) {
-  const resp = await libnpm.manifest(packageName)
+  const resp = await pacote.manifest(packageName)
   return new Manifest(resp)
 }

--- a/package.json
+++ b/package.json
@@ -51,11 +51,10 @@
     "install": "^0.13.0",
     "js-yaml": "^3.13.1",
     "level": "^5.0.1",
-    "libnpm": "^2.0.1",
     "lit-element": "^2.2.1",
     "nighthawk": "^2.3.0-1",
     "node-fetch": "^2.6.0",
-    "npm": "^6.10.3",
+    "pacote": "^20.0.0",
     "regenerator-runtime": "^0.13.3",
     "yargs": "^13.3.0"
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
`libnpm` is no longer maintained by `npm`, and in its place, they created `pacote`. It doesn't introduce any breaking changes, as far as I can tell.