### PR TITLE
deps: remove regenerator-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cptmpl": "0.0.4",
     "dotenv": "^8.0.0",
     "es5-lit-element": "^2.2.1",
+    "es5-lit-html": "^1.1.1",
     "express": "^4.17.1",
     "fs-extra": "^8.1.0",
     "inquirer": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "lit-element": "^2.2.1",
     "nighthawk": "^2.3.0-1",
     "pacote": "^20.0.0",
-    "regenerator-runtime": "^0.13.3",
     "yargs": "^13.3.0"
   },
   "engines": {

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -1,7 +1,6 @@
 'use strict'
 /* eslint-disable */
 /* eslint-env browser */
-require('regenerator-runtime/runtime')
 const { html } = require('es5-lit-element')
 const { render } = require('es5-lit-html')
 const config = window.__config || {}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
AsyncGenerator was included in Node.js 10, this dependency is unnecessary