### PR TITLE
Use undici instead of node-fetch

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -1,27 +1,30 @@
 'use strict'
-const fetch = require('node-fetch')
+const { request } = require('undici')
 const yaml = require('js-yaml')
 const GHRAW = 'https://raw.githubusercontent.com/'
 
 module.exports.getPackageJson = async function getPackageJson (project) {
-  const resp = await fetch(`${GHRAW}${project.repoOwner}/${project.repoName}/${project.repoBranch}${project.repoDirectory}package.json`)
-  if (resp.status !== 200) {
-    const e = new Error(`Non-200 Response: ${resp.status}`)
-    e.status = resp.status
-    e.body = await resp.text()
+  const resp = await request(`${GHRAW}${project.repoOwner}/${project.repoName}/${project.repoBranch}${project.repoDirectory}package.json`)
+  if (resp.statusCode !== 200) {
+    const e = new Error(`Non-200 Response: ${resp.statusCode}`)
+    e.status = resp.statusCode
+    e.body = await resp.body.text()
     throw e
   }
-  return resp.json()
+  return resp.body.json()
 }
 
 module.exports.getTravisConfig = async function getTravisConfig (project) {
-  const resp = await fetch(`${GHRAW}${project.repoOwner}/${project.repoName}/${project.repoBranch}${project.repoDirectory}.travis.yml`)
-  if (resp.status !== 200) {
-    const e = new Error(`Non-200 Response: ${resp.status}`)
-    e.status = resp.status
-    e.body = await resp.text()
+  const resp = await request(`${GHRAW}${project.repoOwner}/${project.repoName}/${project.repoBranch}${project.repoDirectory}.travis.yml`)
+
+  if (resp.statusCode !== 200) {
+    const e = new Error(`Non-200 Response: ${resp.statusCode}`)
+    e.status = resp.statusCode
+    e.body = await resp.body.text()
     throw e
   }
-  const travisTxt = await resp.text()
+
+  const travisTxt = await resp.body.text()
+
   return yaml.safeLoad(travisTxt)
 }

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     "libnpm": "^2.0.1",
     "lit-element": "^2.2.1",
     "nighthawk": "^2.3.0-1",
-    "node-fetch": "^2.6.0",
     "npm": "^6.10.3",
     "regenerator-runtime": "^0.13.3",
+    "undici": "^7.0.0",
     "yargs": "^13.3.0"
   },
   "engines": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
node-fetch is replaced with undici, it might save some time during CI.