### PR TITLE
deps: readd regenrator-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lit-element": "^2.2.1",
     "nighthawk": "^2.3.0-1",
     "pacote": "^20.0.0",
+    "regenerator-runtime": "^0.14.1",
     "yargs": "^13.3.0"
   },
   "engines": {

--- a/template/js/index.js
+++ b/template/js/index.js
@@ -1,6 +1,7 @@
 'use strict'
 /* eslint-disable */
 /* eslint-env browser */
+require('regenerator-runtime/runtime')
 const { html } = require('es5-lit-element')
 const { render } = require('es5-lit-html')
 const config = window.__config || {}


### PR DESCRIPTION
It seems that the compilation process needs these dependencies, perhaps because it is being compiled to ES5.