### PR TITLE
remove README and Travis config request

### DIFF
--- a/lib/db/build-index.js
+++ b/lib/db/build-index.js
@@ -113,26 +113,6 @@ async function * loadProject (octokit, graphQL, project, config, _repo) {
   }
 
   try {
-    yield projectDetail(
-      'README',
-      project,
-      await github.getReadme(graphQL, project.repoOwner, project.repoName, project.primaryBranch)
-    )
-  } catch (e) {
-    yield projectDetail('ERROR', project, e)
-  }
-
-  try {
-    yield projectDetail(
-      'TRAVIS',
-      project,
-      await files.getTravisConfig(project)
-    )
-  } catch (e) {
-    yield projectDetail('ERROR', project, e)
-  }
-
-  try {
     for await (const issue of github.getRepoIssues(graphQL, project.repoOwner, project.repoName)) {
       yield projectDetail('ISSUE', project, issue)
     }

--- a/lib/files.js
+++ b/lib/files.js
@@ -1,5 +1,4 @@
 'use strict'
-const yaml = require('js-yaml')
 const GHRAW = 'https://raw.githubusercontent.com/'
 
 module.exports.getPackageJson = async function getPackageJson (project) {
@@ -11,16 +10,4 @@ module.exports.getPackageJson = async function getPackageJson (project) {
     throw e
   }
   return resp.json()
-}
-
-module.exports.getTravisConfig = async function getTravisConfig (project) {
-  const resp = await fetch(`${GHRAW}${project.repoOwner}/${project.repoName}/${project.repoBranch}${project.repoDirectory}.travis.yml`)
-  if (resp.status !== 200) {
-    const e = new Error(`Non-200 Response: ${resp.status}`)
-    e.status = resp.status
-    e.body = await resp.text()
-    throw e
-  }
-  const travisTxt = await resp.text()
-  return yaml.safeLoad(travisTxt)
 }

--- a/lib/github.js
+++ b/lib/github.js
@@ -343,47 +343,6 @@ async function * getRepoActivity (octokit, owner, repo) {
   }
 }
 
-module.exports.getReadme =
-  async function getReadme (graphQL, owner, repo) {
-    try {
-      const resp = await graphQL({
-        query: ` query($org: String!, $repo: String!) {
-          repository(name: $repo, owner: $org) {
-            object(expression: "master:README.md") {
-              ... on Blob {
-                text
-              }
-            }
-            altLower: object(expression: "master:readme.md") {
-              ... on Blob {
-                text
-              }
-            }
-            altUpper: object(expression: "master:Readme.md") {
-              ... on Blob {
-                text
-              }
-            }
-          }
-        }
-        `,
-        org: owner,
-        repo
-      })
-      let readmeText
-      Object.values(resp.repository).forEach(element => {
-        if (element !== null) {
-          readmeText = element.text
-        }
-      })
-      return readmeText
-    } catch (error) {
-      error.code = 'GET_README_FAILED'
-      Error.captureStackTrace(error, module.exports.getReadme)
-      throw error
-    }
-  }
-
 async function getRemainingRepos (graphQL, org, cursor) {
   try {
     const resp = await graphQL({

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "fs-extra": "^8.1.0",
     "inquirer": "^12.4.2",
     "install": "^0.13.0",
-    "js-yaml": "^3.13.1",
     "level": "^5.0.1",
     "lit-element": "^2.2.1",
     "nighthawk": "^2.3.0-1",

--- a/template/indicies.js
+++ b/template/indicies.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   projects: async (data, config, key, { type, project, detail }) => {
-    if (!['REPO', 'PACKAGE_JSON', 'PACKUMENT', 'TRAVIS'].includes(type)) {
+    if (!['REPO', 'PACKAGE_JSON', 'PACKUMENT'].includes(type)) {
       return data
     }
 
@@ -10,9 +10,6 @@ module.exports = {
     const existing = data.find((p) => p.repo === project.repo)
     const proj = existing || { ...project }
     switch (type) {
-      case 'TRAVIS':
-        proj.travis = detail
-        break
       case 'PACKAGE_JSON':
         proj.packageJson = detail
         break

--- a/template/js/project-list.js
+++ b/template/js/project-list.js
@@ -71,13 +71,6 @@ class ProjectList extends LitElement {
                   </a>
                 `)}
               </td>
-              <td>
-                ${project.travis && (html`
-                  <a href="https://travis-ci.org/${project.repo}">
-                    <img src="https://badgen.net/travis/${project.repo}" />
-                  </a>
-                `)}
-              </td>
             </tr>
           `)}
         </table>


### PR DESCRIPTION
Most of the CI has been moved to GitHub Actions, and the README request doesn’t reference anywhere; it's just another request that doesn't actually do anything.