### PR TITLE
feat: add head meta tags and configuration to support dynamic HTML head content

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,7 @@ const DEFAULTS = {
   template: builder,
   indicies,
   bots: true,
+  head: [],
   title: 'StatusBoard',
   description: 'Project StatusBoard',
   issueLabels: ['top priority', 'good first issue', 'help wanted', 'discussion', 'meeting']
@@ -40,6 +41,7 @@ class Config {
     // All the dynamic stuff for a project
     this.title = opts.title || DEFAULTS.title
     this.description = opts.description || DEFAULTS.description
+    this.head = opts.head || DEFAULTS.head
 
     // Include bots in stats
     this.bots = opts.bots === undefined ? DEFAULTS.bots : opts.bots

--- a/template/index.html
+++ b/template/index.html
@@ -5,11 +5,18 @@
     <title><%= title %></title>
     <meta name="description" content="<%= description %>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    <!-- <link rel="manifest" href="site.webmanifest"> -->
-    <!-- <link rel="apple-touch-icon" href="icon.png"> -->
+    <meta name="robots" content="index, follow" />
+    <meta name="googlebot" content="index, follow" />
     <meta name="theme-color" content="#fafafa">
-    <!-- Place favicon.ico in the root directory -->
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="<%= title %>" />
+    <meta property="og:description" content="<%= description %>" />
+
+    <meta name="twitter:title" content="<%= title %>" />
+    <meta name="twitter:description" content="<%= description %>" />
+
+    <%- head.join('\n') %>
 
     <link href="<%= files.css.index %>" rel="stylesheet" />
     <script>

--- a/test/fixtures/config.js
+++ b/test/fixtures/config.js
@@ -11,7 +11,10 @@ module.exports = {
 
   title: 'StatusBoard Test',
   description: 'A test for StatusBoard',
-
+  head: [
+    '<link rel="me" href="https://social.lfx.dev/@nodejs" />',
+    '<meta name="fediverse:creator" content="@nodejs@social.lfx.dev" />'
+  ],
   orgs: [
     'pkgjs'
   ],


### PR DESCRIPTION
With this, it adds the ability to include tags in the head through configuration, so we can allow the option to add meta tags.

See https://github.com/expressjs/statusboard/issues/6